### PR TITLE
Adds canonical and ogurl

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,6 +2,7 @@ module.exports = {
     siteMetadata: {
         title: 'Anton Ball',
         description: 'Personal site and blog of Anton Ball',
+        siteUrl: 'https://www.antonball.dev/',
     },
     plugins: [
         {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "1.1.3",
   "author": "Anton Ball",
   "dependencies": {
-    "bulma": "^0.8.0",
     "gatsby": "^2.17.9",
     "gatsby-image": "^2.0.30",
     "gatsby-plugin-netlify": "^2.1.23",
@@ -48,6 +47,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.144",
+    "@types/reach__router": "^1.2.6",
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.9.3",
     "@types/react-helmet": "^5.0.14",

--- a/src/Hooks/UseSiteMetadata.ts
+++ b/src/Hooks/UseSiteMetadata.ts
@@ -15,6 +15,7 @@ export const useSiteMetadata = () => {
                     siteMetadata {
                         title
                         description
+                        siteUrl
                     }
                 }
             }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -6,7 +6,7 @@ import { Link, withPrefix } from 'gatsby'
 import { Logo } from './Logo/Logo'
 
 export const Layout: React.FC = ({ children }) => {
-    const { title, description } = useSiteMetadata()
+    const { title, description, siteUrl } = useSiteMetadata()
 
     return (
         <div style={{ width: '60%', minWidth: 300, maxWidth: 900, margin: '0 auto' }}>
@@ -39,10 +39,10 @@ export const Layout: React.FC = ({ children }) => {
                     color="#ff4400"
                 />
                 <meta name="theme-color" content="#f47100" />
+                <meta property="og:url" content={siteUrl} />
 
                 {/* <meta property="og:type" content="business.business" />
         <meta property="og:title" content={title} />
-        <meta property="og:url" content="/" />
         <meta
           property="og:image"
           content={`${withPrefix('/')}img/og-image.jpg`}

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -2,12 +2,24 @@ import React from 'react'
 
 import { Layout } from '../../components/Layout'
 import BlogRoll from '../../components/BlogRoll/BlogRoll'
+import { GatsbyPage } from '../../types/page'
+import { useSiteMetadata } from '../../Hooks/UseSiteMetadata'
+import Helmet from 'react-helmet'
 
-const BlogIndexPage: React.FC = () => (
-    <Layout>
-        <h1>Latest Stories</h1>
-        <BlogRoll />
-    </Layout>
-)
+const BlogIndexPage: React.FC<GatsbyPage> = ({ location }) => {
+    const { siteUrl } = useSiteMetadata()
+    const canonicalUrl = `${siteUrl}${location.pathname}`
+
+    return (
+        <Layout>
+            <Helmet>
+                <link rel="canonical" href={canonicalUrl} />
+                <meta property="og:url" content={canonicalUrl} />
+            </Helmet>
+            <h1>Latest Stories</h1>
+            <BlogRoll />
+        </Layout>
+    )
+}
 
 export default BlogIndexPage

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,19 +1,30 @@
 import React from 'react'
 import { Layout } from '../components/Layout'
 import BlogRoll from '../components/BlogRoll/BlogRoll'
+import Helmet from 'react-helmet'
+import { useSiteMetadata } from '../Hooks/UseSiteMetadata'
 
-const IndexPage: React.FC = () => (
-    <Layout>
-        <main style={{ marginBottom: '1rem' }}>
-            <p>
-                Personal blog of{' '}
-                <a href="https://twitter.com/antonjb" target="_blank" rel="noopener noreferrer">
-                    Anton Ball
-                </a>
-            </p>
-        </main>
-        <BlogRoll />
-    </Layout>
-)
+const IndexPage: React.FC = () => {
+    const { siteUrl } = useSiteMetadata()
+    const canonicalUrl = `${siteUrl}`
+
+    return (
+        <Layout>
+            <Helmet>
+                <link rel="canonical" href={canonicalUrl} />
+                <meta property="og:url" content={canonicalUrl} />
+            </Helmet>
+            <main style={{ marginBottom: '1rem' }}>
+                <p>
+                    Personal blog of{' '}
+                    <a href="https://twitter.com/antonjb" target="_blank" rel="noopener noreferrer">
+                        Anton Ball
+                    </a>
+                </p>
+            </main>
+            <BlogRoll />
+        </Layout>
+    )
+}
 
 export default IndexPage

--- a/src/pages/tags/index.tsx
+++ b/src/pages/tags/index.tsx
@@ -4,8 +4,9 @@ import Helmet from 'react-helmet'
 import { Link, graphql } from 'gatsby'
 import { Layout } from '../../components/Layout'
 import { SiteMeta } from '../../types/frontmatter'
+import { GatsbyPage } from '../../types/page'
 
-interface TagsPageProps {
+interface TagsPageProps extends GatsbyPage {
     data: {
         allMarkdownRemark: {
             group: {
@@ -14,41 +15,43 @@ interface TagsPageProps {
             }[]
         }
         site: {
-            siteMetadata: Pick<SiteMeta, 'title'>
+            siteMetadata: Pick<SiteMeta, 'title' | 'siteUrl'>
         }
     }
 }
 
 const TagsPage: React.FC<TagsPageProps> = ({
+    location,
     data: {
         allMarkdownRemark: { group },
         site: {
-            siteMetadata: { title },
+            siteMetadata: { title, siteUrl },
         },
     },
-}) => (
-    <Layout>
-        <section className="section">
-            <Helmet title={`Tags | ${title}`} />
-            <div className="container content">
-                <div className="columns">
-                    <div className="column is-10 is-offset-1" style={{ marginBottom: '6rem' }}>
-                        <h1 className="title is-size-2 is-bold-light">Tags</h1>
-                        <ul className="taglist">
-                            {group.map(tag => (
-                                <li key={tag.fieldValue}>
-                                    <Link to={`/tags/${kebabCase(tag.fieldValue)}/`}>
-                                        {tag.fieldValue} ({tag.totalCount})
-                                    </Link>
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </section>
-    </Layout>
-)
+}) => {
+    const canonicalUrl = `${siteUrl}${location.pathname}`
+
+    return (
+        <Layout>
+            <section>
+                <Helmet title={`Tags | ${title}`}>
+                    <link rel="canonical" href={canonicalUrl} />
+                    <meta property="og:url" content={canonicalUrl} />
+                </Helmet>
+                <h1>Tags</h1>
+                <ul>
+                    {group.map(tag => (
+                        <li key={tag.fieldValue}>
+                            <Link to={`/tags/${kebabCase(tag.fieldValue)}/`}>
+                                {tag.fieldValue} ({tag.totalCount})
+                            </Link>
+                        </li>
+                    ))}
+                </ul>
+            </section>
+        </Layout>
+    )
+}
 
 export default TagsPage
 
@@ -57,6 +60,7 @@ export const tagPageQuery = graphql`
         site {
             siteMetadata {
                 title
+                siteUrl
             }
         }
         allMarkdownRemark(limit: 1000) {

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -54,7 +54,8 @@ export const BlogPostTemplate: React.FC<BlogPostTemplateProps> = ({
 
 const BlogPost = ({ data }: { data: BlogPostInterface }) => {
     const { markdownRemark: post } = data
-    const { title } = useSiteMetadata()
+    const { title, siteUrl } = useSiteMetadata()
+    const canonicalUrl = `${siteUrl}${post.fields.slug}`
 
     return (
         <Layout>
@@ -66,6 +67,8 @@ const BlogPost = ({ data }: { data: BlogPostInterface }) => {
                     <Helmet titleTemplate={`%s | ${title}`}>
                         <title>{`${post.frontmatter.title}`}</title>
                         <meta name="description" content={`${post.frontmatter.description}`} />
+                        <link rel="canonical" href={canonicalUrl} />
+                        <meta property="og:url" content={canonicalUrl} />
                     </Helmet>
                 }
                 tags={post.frontmatter.tags}
@@ -83,6 +86,9 @@ export const pageQuery = graphql`
         markdownRemark(id: { eq: $id }) {
             id
             html
+            fields {
+                slug
+            }
             frontmatter {
                 date(formatString: "MMMM DD, YYYY")
                 title

--- a/src/templates/tags.tsx
+++ b/src/templates/tags.tsx
@@ -3,8 +3,9 @@ import Helmet from 'react-helmet'
 import { Link, graphql } from 'gatsby'
 import { Layout } from '../components/Layout'
 import { SiteMeta } from '../types/frontmatter'
+import { GatsbyPage } from '../types/page'
 
-interface TagRouteProps {
+interface TagRouteProps extends GatsbyPage {
     data: {
         allMarkdownRemark: {
             totalCount: number
@@ -22,7 +23,7 @@ interface TagRouteProps {
             ]
         }
         site: {
-            siteMetadata: Pick<SiteMeta, 'title'>
+            siteMetadata: Pick<SiteMeta, 'title' | 'siteUrl'>
         }
     }
     pageContext: {
@@ -32,33 +33,33 @@ interface TagRouteProps {
 
 const TagRoute: React.FC<TagRouteProps> = props => {
     const posts = props.data.allMarkdownRemark.edges
-    const postLinks = posts.map(post => (
-        <li key={post.node.fields.slug}>
-            <Link to={post.node.fields.slug}>
-                <h2 className="is-size-2">{post.node.frontmatter.title}</h2>
-            </Link>
-        </li>
-    ))
     const tag = props.pageContext.tag
     const title = props.data.site.siteMetadata.title
     const totalCount = props.data.allMarkdownRemark.totalCount
     const tagHeader = `${totalCount} post${totalCount === 1 ? '' : 's'} tagged with “${tag}”`
+    const canonicalUrl = `${props.data.site.siteMetadata.siteUrl}${props.location.pathname}`
 
     return (
         <Layout>
-            <section className="section">
+            <Helmet>
+                <link rel="canonical" href={canonicalUrl} />
+                <meta property="og:url" content={canonicalUrl} />
+            </Helmet>
+            <section>
                 <Helmet title={`${tag} | ${title}`} />
-                <div className="container content">
-                    <div className="columns">
-                        <div className="column is-10 is-offset-1" style={{ marginBottom: '6rem' }}>
-                            <h3 className="title is-size-4 is-bold-light">{tagHeader}</h3>
-                            <ul className="taglist">{postLinks}</ul>
-                            <p>
-                                <Link to="/tags/">Browse all tags</Link>
-                            </p>
-                        </div>
-                    </div>
-                </div>
+                <h3 className="title is-size-4 is-bold-light">{tagHeader}</h3>
+                <ul className="taglist">
+                    {posts.map(post => (
+                        <li key={post.node.fields.slug}>
+                            <Link to={post.node.fields.slug}>
+                                <h2>{post.node.frontmatter.title}</h2>
+                            </Link>
+                        </li>
+                    ))}
+                </ul>
+                <p>
+                    <Link to="/tags/">Browse all tags</Link>
+                </p>
             </section>
         </Layout>
     )
@@ -71,6 +72,7 @@ export const tagPageQuery = graphql`
         site {
             siteMetadata {
                 title
+                siteUrl
             }
         }
         allMarkdownRemark(

--- a/src/types/blogpost.ts
+++ b/src/types/blogpost.ts
@@ -4,6 +4,9 @@ export interface BlogPostInterface {
     markdownRemark: {
         id: string
         html: string
+        fields: {
+            slug: string
+        }
         frontmatter: {
             date: string
             title: string

--- a/src/types/frontmatter.ts
+++ b/src/types/frontmatter.ts
@@ -1,4 +1,5 @@
 export interface SiteMeta {
     title: string
     description: string
+    siteUrl: string
 }

--- a/src/types/page.ts
+++ b/src/types/page.ts
@@ -1,0 +1,21 @@
+export interface GatsbyPage {
+    location: {
+        hash: string
+        host: string
+        hostname: string
+        href: string
+        key: string
+        origin: string
+        pathname: string
+        port: string
+        protocol: string
+        // TODO: types?
+        // reload
+        // replace
+        search: string
+        state: any
+        // toString
+    }
+    path: string
+    url: string
+}


### PR DESCRIPTION
Adds the siteUrl property to metadata so that the correct og:url and
canonical url could be populated. Added to the useSiteMetadata hook and
a new interface defined for the pages using reach router's path

Removed bulma as a dependency as it wasn't used and cleaned up the tag
pages because they had a lot of extra wrappers and classes that weren't
required